### PR TITLE
Add whole-archive link for static build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ build
 *.bak
 /.PVS-Studio
 *.cfg
+fhDOOM.AppImage

--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ Setup:
   * `dist_nopatch`: same as `dist` but without the files from the 1.31 patch
   * `sdk`: generates a SDK to build only a game dll for D3Foxed (this is currently not used, not sure if its still working)
 
+### Static build on Linux
+
+The CMake setup already links the `game_fracture` module directly into `fhDOOM`.
+Avoid defining `__DOOM_DLL__` or `GAME_DLL` when configuring to produce a self-contained executable. The build uses `--whole-archive` so that all game objects, including script events, are linked in. Simply run cmake followed by make.
+### Creating an AppImage
+
+After building, run `scripts/create_appimage.sh` to bundle the game.
+It expects `release/fhDOOM` and the `release/base` data directory and uses `appimagetool` to create `fhDOOM.AppImage`.
+
 ### Similar Projects
 
   There exist other forks of the DOOM3 engine and even id software released a modernized version of DOOM3 and its engine as "DOOM 3 - BFG Edition".

--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -1074,6 +1074,14 @@ add_executable(${TARGET_NAME} ${SOURCES})
 target_link_libraries(${TARGET_NAME} ${LINK_LIBS})
 get_property(GAME_TARGET_NAME GLOBAL PROPERTY GLOB_GAME_TARGET_NAME)
 get_property(D3XP_TARGET_NAME GLOBAL PROPERTY GLOB_D3XP_TARGET_NAME)
+if (GAME_TARGET_NAME)
+    target_link_libraries(${TARGET_NAME}
+            "-Wl,--whole-archive" ${GAME_TARGET_NAME} "-Wl,--no-whole-archive")
+endif()
+if (D3XP_TARGET_NAME)
+    target_link_libraries(${TARGET_NAME}
+            "-Wl,--whole-archive" ${D3XP_TARGET_NAME} "-Wl,--no-whole-archive")
+endif()
 add_dependencies(${TARGET_NAME} ${GAME_TARGET_NAME} ${D3XP_TARGET_NAME})
 
 if (Qt5Widgets_FOUND)

--- a/scripts/create_appimage.sh
+++ b/scripts/create_appimage.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+# Create an AppImage from a built fhDOOM binary.
+# The script expects the binary to reside at release/fhDOOM
+# and game data to be present in release/base.
+# Set APPIMAGE_TOOL to override the path to the appimagetool utility.
+
+APPIMAGE_TOOL=${APPIMAGE_TOOL:-appimagetool}
+
+if [ ! -x "release/fhDOOM" ]; then
+  echo "release/fhDOOM not found" >&2
+  exit 1
+fi
+
+WORKDIR=$(mktemp -d)
+APPDIR="$WORKDIR/fhDOOM.AppDir"
+
+mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/share/fhdoom"
+
+cp release/fhDOOM "$APPDIR/usr/bin/"
+cp -r release/base "$APPDIR/usr/share/fhdoom/"
+
+cat > "$APPDIR/fhDOOM.desktop" <<DESKTOP
+[Desktop Entry]
+Type=Application
+Name=fhDOOM
+Exec=fhDOOM
+Icon=fhdoom
+Categories=Game;
+DESKTOP
+
+cp resources/icon.png "$APPDIR/fhdoom.png"
+
+"$APPIMAGE_TOOL" "$APPDIR" fhDOOM.AppImage
+
+echo "AppImage written to fhDOOM.AppImage"
+


### PR DESCRIPTION
## Summary
- ensure the game code is fully linked when building fhDOOM statically
- document that the build uses `--whole-archive` so script events work

## Testing
- `cmake -B build2 -S .` *(fails: CMake 4.0.0 or higher is required)*
- `bash scripts/create_appimage.sh` *(fails: release/fhDOOM not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c06c74ac832a929dc35df9de2e45